### PR TITLE
sdm710-common: enable SAE/WPA3

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -605,8 +605,8 @@ gChannelBondingMode24GHz=0
 #Enable ETSI SRD channels in master mode PCL and ACS functionality
 etsi13_srd_chan_in_master_mode=1
 
-# Disable wpa3 on 7150 device
-sae_enabled=0
+# Enable wpa3 on 7150 device
+sae_enabled=1
 
 # Reduce the expiry time for avoid list and black list in drv.
 avoid_list_expiry_time=3


### PR DESCRIPTION
WPA3 working well on grus and enabled by default in crDroid and PixelExpirience builds.